### PR TITLE
Add properties file pointing to the new staging environment

### DIFF
--- a/src/properties/properties-staging-bip.js
+++ b/src/properties/properties-staging-bip.js
@@ -1,0 +1,21 @@
+import defaultProps from './properties-default'
+
+const env = defaultProps
+
+const ldsBaseUrl = "https://workbench.staging-bip-app.ssb.no/be/lds-c"
+
+export default {
+  ...env,
+  api: {
+    lds: ldsBaseUrl,
+    backend: "https://workbench.staging-bip-app.ssb.no/be/workbench-backend/",
+    role: ldsBaseUrl + "/ns/Role/",
+    dataResource: ldsBaseUrl + "/ns/DataResource/",
+    notebookService: 'https://workbench.staging-bip-app.ssb.no/be/workbench-backend/api/'
+  },
+  oauth: {
+    authority: 'https://accounts.google.com',
+    client_id: window._env_.OAUTH_CLIENT_ID,
+    redirect_uri: window.location.origin + '/implicit/callback'
+  }
+}

--- a/src/properties/properties.js
+++ b/src/properties/properties.js
@@ -14,6 +14,10 @@ if (process.env.NODE_ENV === 'test') {
       properties = require('./properties-staging')
       break
     }
+    case 'staging-bip': {
+      properties = require('./properties-staging-bip')
+      break
+    }
     case 'production': {
       properties = require('./properties-production')
       break


### PR DESCRIPTION
We are currently having two staging environments. Avoiding services disruption in the transition period this will allow starting Workbench UI application on both staging environments.