### PR TITLE
Rename new staging environment variable

### DIFF
--- a/src/properties/properties.js
+++ b/src/properties/properties.js
@@ -14,7 +14,7 @@ if (process.env.NODE_ENV === 'test') {
       properties = require('./properties-staging')
       break
     }
-    case 'staging-bip': {
+    case 'staging_bip': {
       properties = require('./properties-staging-bip')
       break
     }


### PR DESCRIPTION
Both workbench-ui and workbench-backend must have identical variable name for environment. Due to https://github.com/statisticsnorway/be-workbench/pull/19 there is a need to change this variable name here as well